### PR TITLE
Updating the cert-manager to latest version

### DIFF
--- a/yaml-solutions/advanced/frontend-ingress-tls.yaml
+++ b/yaml-solutions/advanced/frontend-ingress-tls.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: frontend
   annotations:
-    certmanager.k8s.io/cluster-issuer: letsencrypt
+    cert-manager.io/cluster-issuer: letsencrypt
 spec:
   tls:
   - hosts:

--- a/yaml-solutions/advanced/letsencrypt-clusterissuer.yaml
+++ b/yaml-solutions/advanced/letsencrypt-clusterissuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: letsencrypt
@@ -9,4 +9,7 @@ spec:
     email: _YOUR_EMAIL_ # replace this with your email
     privateKeySecretRef:
       name: letsencrypt
-    http01: {}
+    solvers:
+       - http01:
+           ingress:
+             class:  nginx


### PR DESCRIPTION
Problem as described here https://github.com/microsoft/aksworkshop/issues/31 
Issue - cert-manager version v0.5.2 is pretty old and is no longer supported. Updating the installation instructions and change of domain for cert-manager in `annotations` for `Ingress` and in `apiVersion` for `ClusterIssuer` 