### PR TITLE
Adding missing environment variable for MongoUser

### DIFF
--- a/yaml-solutions/advanced/captureorder-deployment-flexvol.yaml
+++ b/yaml-solutions/advanced/captureorder-deployment-flexvol.yaml
@@ -39,6 +39,11 @@ spec:
               secretKeyRef:
                 name: mongodb
                 key: mongoHost
+          - name: MONGOUSER
+            valueFrom:
+              secretKeyRef:
+                name: mongodb
+                key: mongoUser
           ports:
           - containerPort: 8080
           volumeMounts:


### PR DESCRIPTION
The Azure Key Vault Integration YAML file example is missing the environment variable for MONGOUSER - the doc steps have it though. 
This PR fixes https://github.com/microsoft/aksworkshop/issues/35 