### PR TITLE
Add missing create namespace command

### DIFF
--- a/_entries/02-04 challenge2-3.md
+++ b/_entries/02-04 challenge2-3.md
@@ -153,6 +153,8 @@ NGINX ingress controller is easily deployed with helm:
 ```sh
 helm repo update
 
+kubectl create namespace ingress
+
 helm upgrade --install ingress stable/nginx-ingress --namespace ingress
 ```
 


### PR DESCRIPTION
Added missing command to create namespace for ingress. If the namespace does not exist, the next command will produce an error