### PR TITLE
Get version query which does not include preview orchestrator versions

### DIFF
--- a/_entries/02-01 challenge1.md
+++ b/_entries/02-01 challenge1.md
@@ -16,7 +16,7 @@ Azure has a managed Kubernetes service, AKS (Azure Kubernetes Service), we'll us
 Get the latest available Kubernetes version in your preferred region into a bash variable. Replace `<region>` with the region of your choosing, for example `eastus`.
 
 ```sh
-version=$(az aks get-versions -l <region> --query 'orchestrators[-1].orchestratorVersion' -o tsv)
+version=$(az aks get-versions -l westeurope --query 'orchestrators[?!isPreview] | [-1].orchestratorVersion' -o tsv)
 ```
 
 {% endcollapsible %}

--- a/_entries/02-01 challenge1.md
+++ b/_entries/02-01 challenge1.md
@@ -13,10 +13,10 @@ Azure has a managed Kubernetes service, AKS (Azure Kubernetes Service), we'll us
 
 {% collapsible %}
 
-Get the latest available Kubernetes version in your preferred region into a bash variable. Replace `<region>` with the region of your choosing, for example `eastus`.
+Get the latest available Kubernetes version in your preferred region into a bash variable. Replace `<region>` with the region of your choosing, for example `eastus`. The query also filters out preview versions.
 
 ```sh
-version=$(az aks get-versions -l westeurope --query 'orchestrators[?!isPreview] | [-1].orchestratorVersion' -o tsv)
+version=$(az aks get-versions -l <region> --query 'orchestrators[?!isPreview] | [-1].orchestratorVersion' -o tsv)
 ```
 
 {% endcollapsible %}


### PR DESCRIPTION
In order to avoid people spinning up preview aks clusters you can query the json returned by the az aks get-version command to filter out preview versions before getting the first one.