### PR TITLE
Changes to sections 1 and 2

### DIFF
--- a/_entries/01 introduction.md
+++ b/_entries/01 introduction.md
@@ -10,14 +10,10 @@ Welcome to the Azure Kubernetes Workshop. In this lab, you'll go through tasks t
 
 You can use this guide as a Kubernetes tutorial and as study material to help you get started to learn Kubernetes.
 
-If you are new to Kubernetes, start with the [Kubernetes Learning Path](https://aka.ms/LearnKubernetes) to learn Kubernetes basics, then go through the concepts of [what Kubernetes is and what it isn't](https://aka.ms/k8sLearning).
-
-If you are a more experienced Kubernetes developer or administrator, you may have a look at the [Kubernetes best practices ebook](https://aka.ms/aks/bestpractices).
-
 Some of the things you’ll be going through:
 
 - Kubernetes deployments, services and ingress
-- Deploying MongoDB using Helm 2 (the instructions below are specifically for Helm 2 and will be later updated to Helm 3)
+- Deploying MongoDB using Helm version 3
 - Azure Monitor for Containers, Horizontal Pod Autoscaler and the Cluster Autoscaler
 - Building CI/CD pipelines using Azure DevOps and Azure Container Registry
 - Scaling using Virtual Nodes, setting up SSL/TLS for your deployments, using Azure Key Vault for secrets

--- a/_entries/01-01 prerequisites.md
+++ b/_entries/01-01 prerequisites.md
@@ -68,12 +68,8 @@ You should now have access to the Azure Cloud Shell
 
 {% endcollapsible %}
 
-#### Uploading and editing files in Azure Cloud Shell
-
-{% collapsible %}
+#### Tips for uploading and editing files in Azure Cloud Shell
 
 - You can use `code <file you want to edit>` in Azure Cloud Shell to open the built-in text editor.
 - You can upload files to the Azure Cloud Shell by dragging and dropping them
 - You can also do a `curl -o filename.ext https://file-url/filename.ext` to download a file from the internet.
-
-{% endcollapsible %}

--- a/_entries/01-02 k8sbasics.md
+++ b/_entries/01-02 k8sbasics.md
@@ -5,4 +5,6 @@ title: Kubernetes basics
 parent-id: intro
 ---
 
-There is an assumption of some prior knowledge of Kubernetes and its concepts.
+There is an assumption of some prior knowledge of Kubernetes and its concepts. If you are new to Kubernetes, start with the [Kubernetes Learning Path](https://aka.ms/LearnKubernetes) to learn Kubernetes basics, then go through the concepts of [what Kubernetes is and what it isn't](https://aka.ms/k8sLearning).
+
+If you are a more experienced Kubernetes developer or administrator, you may have a look at the [Kubernetes best practices ebook](https://aka.ms/aks/bestpractices).

--- a/_entries/01-05 challenges.md
+++ b/_entries/01-05 challenges.md
@@ -5,17 +5,17 @@ title: Tasks
 parent-id: intro
 ---
 
-Useful resources are provided to help you work through each task. To ensure you progress at a good pace ensure workload is divided between team members where possible. This may mean anticipating work that might be required in a later task.
+Useful resources are provided to help you work through each task. If you're working through this as part of a team based hack, ensure you make progress at a good pace by dividing the workload between team members where possible. This may mean anticipating work that might be required in a later task.
 
 > **Hint**: If you get stuck, you can ask for help from the proctors. You may also choose to peek at the solutions.
 
 ### Core tasks
 
-You are expected to at least complete the **Getting up and running** section. This involves setting up a Kubernetes cluster, deploying the application containers from Docker Hub, setting up monitoring and scaling your application.
+Running through this as part of a one day workshop, you should be able to complete all of the **Getting up and running** section. This involves setting up a Kubernetes cluster, deploying the application containers from Docker Hub, setting up monitoring and scaling your application.
 
 ### DevOps tasks
 
-Once you're done with the above, next would be to include some DevOps. **Complete as many tasks as you can**. You'll be setting up a Continuous Integration and Continuous Delivery pipeline for your application and then using Helm to deploy it.
+Once you're done with the Core tasks, next would be to include some DevOps. **Complete as many tasks as you can**. You'll be setting up a Continuous Integration and Continuous Delivery pipeline for your application and then using Helm to deploy it.
 
 ### Advanced cluster tasks
 

--- a/_entries/02-01 challenge1.md
+++ b/_entries/02-01 challenge1.md
@@ -13,10 +13,16 @@ Azure has a managed Kubernetes service, AKS (Azure Kubernetes Service), we'll us
 
 {% collapsible %}
 
-Get the latest available Kubernetes version in your preferred region into a bash variable. Replace `<region>` with the region of your choosing, for example `eastus`.
+Get the latest available Kubernetes version in your preferred region and store it in a bash variable. Replace `<region>` with the region of your choosing, for example `eastus`.
 
 ```sh
 version=$(az aks get-versions -l <region> --query 'orchestrators[-1].orchestratorVersion' -o tsv)
+```
+
+The above command lists all versions of Kubernetes available to deploy using AKS. Newer Kubernetes releases are typically made available in "Preview". To get the latest non-preview version of Kubernetes, use the following command instead
+
+```sh
+version=$(az aks get-versions -l <region> --query 'orchestrators[?isPreview == null].[orchestratorVersion][-1]' -o tsv)
 ```
 
 {% endcollapsible %}
@@ -37,7 +43,7 @@ az group create --name <resource-group> --location <region>
 
 **Task Hints**
 * It's recommended to use the Azure CLI and the `az aks create` command to deploy your cluster. Refer to the docs linked in the Resources section, or run `az aks create -h` for details
-* The size and number of nodes in your cluster is not critical but two or more nodes of `DS2_v2` or larger is recommended
+* The size and number of nodes in your cluster is not critical but two or more nodes of type `Standard_DS2_v2` or larger is recommended
 
 > **Note** You can create AKS clusters that support the [cluster autoscaler](https://docs.microsoft.com/en-us/azure/aks/cluster-autoscaler#about-the-cluster-autoscaler).
 
@@ -79,9 +85,9 @@ Create AKS using the latest version (if using the provided lab environment)
 ##### **Option 2 ** Create an AKS cluster with the cluster autoscaler
 
  
-  AKS clusters that support the cluster autoscaler must use virtual machine scale sets and run Kubernetes version *1.12.4* or later. 
-
-  Use the `az aks create` command specifying the `--enable-cluster-autoscaler` parameter, and a node `--min-count` and `--max-count`.
+  AKS clusters create worker nodes in Virtual Machine Scale Sets by default. The number of nodes can be easily scaled up and down as required. AKS also supports the Kubernetes Cluster Autoscaler, which will automatically scale the number of nodes on demand to meet current system requirements. 
+  
+  To enable the Cluster Autoscaler, use the `az aks create` command specifying the `--enable-cluster-autoscaler` parameter, and a node `--min-count` and `--max-count`.
   
 Create AKS using the latest version (if using the provided lab environment)
 
@@ -127,7 +133,7 @@ Create AKS using the latest version (on your own subscription)
 #### Ensure you can connect to the cluster using `kubectl`
 
 **Task Hints**
-* `kubectl` is the main command line tool you will using for working with Kubernetes and AKS. It is already installed in the Azure Cloud Shell
+* `kubectl` is the main command line tool you will be using for working with Kubernetes and AKS. It is already installed in the Azure Cloud Shell
 * Refer to the AKS docs which includes [a guide for connecting kubectl to your cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough#connect-to-the-cluster) (Note. using the cloud shell you can skip the `install-cli` step).
 * A good sanity check is listing all the nodes in your cluster `kubectl get nodes`.
 * [This is a good cheat sheet](https://linuxacademy.com/site-content/uploads/2019/04/Kubernetes-Cheat-Sheet_07182019.pdf) for kubectl.

--- a/_entries/02-02 challenge2-1.md
+++ b/_entries/02-02 challenge2-1.md
@@ -6,7 +6,7 @@ parent-id: upandrunning
 title: Deploy MongoDB
 ---
 
-You need to deploy MongoDB in a way that is scalable and production ready. There are a couple of ways to do so.
+You need to deploy MongoDB in a way that is scalable and production ready.
 
 **Task Hints**
 * Use Helm and a standard provided Helm chart to deploy MongoDB.
@@ -18,11 +18,11 @@ You need to deploy MongoDB in a way that is scalable and production ready. There
 
 #### Setup Helm
 
-Helm is an application package manager for Kubernetes, and way to easily deploy applications and services into Kubernetes, via what are called charts. To use Helm you will need the `helm` command (already installed in the Azure Cloud Shell).
+Helm is an application package manager for Kubernetes, and a way to easily deploy applications and services into Kubernetes, via what are called charts. To use Helm you will need the `helm` command (This is already installed if you're using the Azure Cloud Shell).
 
 **Task Hints**
-* The instructions have been updated to use [Helm 3](https://helm.sh/blog/helm-3-released/).
-* Helm 3 does not come with any repositories predefined, you'll need initialize the [stable chart repository](https://v3.helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository)
+* These instructions use [Helm version 3](https://helm.sh/blog/helm-3-released/).
+* Helm version 3 does not come with any repositories predefined, so you'll need initialize the [stable chart repository](https://v3.helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository)
 
 {% collapsible %}
 
@@ -38,39 +38,39 @@ Upate the repositories
 
 #### Deploy an instance of MongoDB to your cluster
 
-Helm provides a standard repository of charts for many different software packages, and it has one for [MongoDB](https://github.com/helm/charts/tree/master/stable/mongodb) that is easily replicated and horizontally scalable. 
+A standard repository of Helm charts is available for many different software packages, and it has one for [MongoDB](https://github.com/helm/charts/tree/master/stable/mongodb) that is easily replicated and horizontally scalable. 
 
 **Task Hints**
-* When installing a chart Helm uses a concept called a "release", and this release needs a name. You should give your release a name and it is strongly recommend you use `orders-mongo` as the name, as we'll need to refer to it later
+* When installing a chart, Helm uses a concept called a "release" and each release needs a name. We recommend you name your release `orders-mongo` to make it easier to follow later steps in this workshop
 * When deploying a chart you provide parameters with the `--set` switch and a comma separated list of `key=value` pairs. There are MANY parameters you can provide to the MongoDB chart, but pay attention to the `mongodbUsername`, `mongodbPassword` and `mongodbDatabase` parameters 
 
-> **Note** The application expects a database called `akschallenge`. Please DO NOT modify it.
+> **Note** The application expects a database named `akschallenge`. Using a different database name will cause the application to fail!
 
 {% collapsible %}
-The recommended way to deploy MongoDB would be to use Helm. 
+The recommended way to deploy MongoDB would be to use a Helm Chart. 
 
 ```sh
 helm install orders-mongo stable/mongodb --set mongodbUsername=orders-user,mongodbPassword=orders-password,mongodbDatabase=akschallenge
 ```
 
-> **Hint** By default, the service load balancing the MongoDB cluster would be accessible at ``orders-mongo-mongodb.default.svc.cluster.local``
+> **Hint** Using this command, the Helm Chart will expose the MongoDB instance as a Kubernetes Service accessible at ``orders-mongo-mongodb.default.svc.cluster.local``
 
-You'll need to use the user created in the command above when configuring the deployment environment variables.
+Remember to use the username and password from the command above when creating the Kubernetes secrets in the next step.
 
 {% endcollapsible %}
 
 #### Create a Kubernetes secret to hold the MongoDB details
 
-In the previous step, you installed MongoDB using Helm, with a specified username, password and a hostname where the database is accessible. You'll now create a Kubernetes secret called mongodb to hold those details, so that you don't need to hard-code them in the YAML files.
+In the previous step, you installed MongoDB using Helm, with a specified username, password and a hostname where the database is accessible. You'll now create a Kubernetes secret called `mongodb` to hold those details, so that you don't need to hard-code them in the YAML files.
 
 **Task Hints**
-* A Kubernetes secret can hold several items, indexed by key. The name of the secret isn't critical, but you'll need three keys stored your secret:
+* A Kubernetes secret can hold several items, indexed by key. The name of the secret isn't critical, but you'll need three keys to store your secret data:
   * `mongoHost`
   * `mongoUser`
   * `mongoPassword`
-* The values for the username & password will be what you used on the `helm install` command when deploying MongoDB.
+* The values for the username & password will be those you used with the `helm install` command when deploying MongoDB.
 * Run `kubectl create secret generic -h` for help on how to create a secret, clue: use the `--from-literal` parameter to allow you to provide the secret values directly on the command in plain text.
-* The value of `mongoHost`, will be dependant on the name of the MongoDB service. The service was created by the Helm chart and will start with the release name you gave. Run `kubectl get service` and you should see it listed, e.g. `orders-mongo-mongodb`
+* The value of `mongoHost`, will be dependent on the name of the MongoDB service. The service was created by the Helm chart and will start with the release name you gave. Run `kubectl get service` and you should see it listed, e.g. `orders-mongo-mongodb`
 * All services in Kubernetes get DNS names, this is assigned automatically by Kubernetes, there's no need for you to configure it. You can use the short form which is simply the service name, e.g. `orders-mongo-mongodb` or better to use the "fully qualified" form `orders-mongo-mongodb.default.svc.cluster.local`
   
 {% collapsible %}
@@ -79,7 +79,7 @@ In the previous step, you installed MongoDB using Helm, with a specified usernam
 kubectl create secret generic mongodb --from-literal=mongoHost="orders-mongo-mongodb.default.svc.cluster.local" --from-literal=mongoUser="orders-user" --from-literal=mongoPassword="orders-password"
 ```
 
-You'll need to use the user created in the command above when configuring the deployment environment variables.
+You'll need to reference this secret when configuring the Order Capture application later on.
 
 {% endcollapsible %}
 
@@ -89,6 +89,10 @@ You'll need to use the user created in the command above when configuring the de
 > * <https://kubernetes.io/docs/concepts/configuration/secret/>
 
 ### Architecture Diagram
-If you want a picture of how the system should look at the end of this challenge click below
+Here's a high level diagram of the components you will have deployed when you've finished this section (click the picture to enlarge)
 
 <a href="media/architecture/mongo.png" target="_blank"><img src="media/architecture/mongo.png" style="width:500px"></a>
+
+* The **pod** holds the containers that run MongoDB
+* The **deployment** manages the pod
+* The **service** exposes the pod to the Internet using a public IP address and a specified port

--- a/_entries/02-04 challenge2-3.md
+++ b/_entries/02-04 challenge2-3.md
@@ -6,15 +6,17 @@ parent-id: upandrunning
 title: Deploy the frontend using Ingress
 ---
 
-You need to deploy the **Frontend** ([azch/frontend](https://hub.docker.com/r/azch/frontend/)). This requires an external endpoint, exposing the website on port 80 and needs to connect to the Order Capture API public IP so it can display the status on the number of orders in the system.
+You need to deploy the **Frontend** application ([azch/frontend](https://hub.docker.com/r/azch/frontend/)). This requires an external endpoint, exposing the website on port 80 and it needs to connect to the Order Capture API's public IP address so that it can display the number of orders in the system.
+
+We want to access the Frontend application using a DNS hostname rather than an IP address. 
 
 ### Container images and source code
 
 In the table below, you will find the Docker container images provided by the development team on Docker Hub as well as their corresponding source code on GitHub.
 
-| Component                    | Docker Image                                                     | Source Code                                                       | Build Status |
-|------------------------------|------------------------------------------------------------------|-------------------------------------------------------------------|--------------|
-| Frontend            | [azch/frontend](https://hub.docker.com/r/azch/frontend/) | [source-code](https://github.com/Azure/azch-frontend)         | [![Build Status](https://dev.azure.com/theazurechallenge/Kubernetes/_apis/build/status/Code/Azure.azch-frontend)](https://dev.azure.com/theazurechallenge/Kubernetes/_build/latest?definitionId=17) |
+| Component                    | Docker Image                                                     | Source Code                                                       | 
+|------------------------------|------------------------------------------------------------------|-------------------------------------------------------------------|
+| Frontend            | [azch/frontend](https://hub.docker.com/r/azch/frontend/) | [source-code](https://github.com/Azure/azch-frontend)         |
 
 ### Environment variables
 
@@ -24,16 +26,16 @@ The frontend requires the `CAPTUREORDERSERVICEIP` environment variable to be set
 
 ### Tasks
 
-#### Provision the `frontend` deployment
+#### Deploy the `frontend` application
 
 **Task Hints**
 * As with the captureorder deployment you will need to create a YAML file which describes your deployment. Making a copy of your captureorder deployment YAML would be a good start, but beware you will need to change
   * `image`
-  * `readinessProbe` (if you have one) endpoint clue use the root url '/'
-  * `livenessProbe` (if you have one) endpoint, clue use the root url '/'
+  * `readinessProbe` endpoint, if you have one (clue use the root url '/')
+  * `livenessProbe` endpoint, if you have one (clue use the root url '/')
 * As before you need to provide environmental variables to your container using `env`, but this time nothing is stored in a secret
 * The container listens on port 8080 
-* If your pods are not starting, not ready or are crashing, you can view their logs using `kubectl logs <pod name>` and/or `kubectl describe pod <pod name>`
+* If your pods are not starting, not ready or are crashing, you can view their logs and detailed status information using `kubectl logs <pod name>` and/or `kubectl describe pod <pod name>`
   
 {% collapsible %}
 
@@ -94,27 +96,27 @@ kubectl apply -f frontend-deployment.yaml
 kubectl get pods -l app=frontend -w
 ```
 
-> **Hint** If the pods are not starting, not ready or are crashing, you can view their logs using `kubectl logs <pod name>` and `kubectl describe pod <pod name>`.
+> **Hint** If the pods are not starting, not ready or are crashing, you can view their logs and detailed status information using `kubectl logs <pod name>` and `kubectl describe pod <pod name>`.
 
 {% endcollapsible %}
 
-#### Expose the frontend on a hostname
+#### Expose the frontend using a hostname
 
-Instead of accessing the frontend through an IP address, you would like to expose the frontend over a hostname. Explore using [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) to achieve this purpose.
+Instead of accessing the frontend through an IP address, you would like to expose the frontend using a hostname. Explore using [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) to achieve this.
 
-As there are many options out there for ingress controllers, we will stick to the tried and true [nginx-ingress](https://github.com/helm/charts/tree/master/stable/nginx-ingress) controller, which is the most popular albeit not the most featureful controller.
+There are many options when considering Kubernetes ingress controllers, including the [Azure Application Gateway Ingress Controller](https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-overview)  The most commonly used is the [nginx-ingress](https://github.com/helm/charts/tree/master/stable/nginx-ingress) controller.
 
-> **Ingress controller** The Ingress controller is exposed to the internet by using a Kubernetes service of type LoadBalancer. The Ingress controller watches and implements Kubernetes Ingress resources, which creates routes to application endpoints.
+> The Ingress controller is exposed to the internet by using a Kubernetes service of type LoadBalancer. The Ingress controller watches and implements Kubernetes Ingress resources, which creates routes to application endpoints.
 
-We will leverage the [nip.io](https://nip.io/) reverse wildcard DNS resolver service to map our ingress controller `LoadBalancerIP` to a proper DNS name.
+We can leverage the [nip.io](https://nip.io/) reverse wildcard DNS resolver service to map our ingress controller's `LoadBalancerIP` to a proper DNS name.
 
 **Task Hints**
-* When placing services behind an ingress you don't expose them directly with the `LoadBalancer` type, instead you use a `ClusterIP`. In this network model, external clients access your service via public IP of the *ingress controller*
-* [This picture helps explain how this looks and hangs together](media/architecture/ingress.png)
+* When placing services behind an ingress you don't expose them directly with the `LoadBalancer` type, instead you use a `ClusterIP`. In this network model, external clients access your service via public IP of the *ingress controller*, which then decides where to route the traffic within your Kubernetes cluster.
+* [This picture helps explain how this works](media/architecture/ingress.png)
 * Use Helm to deploy The NGINX ingress controller. [The Helm chart for the NGINX ingress controller](https://github.com/helm/charts/tree/master/stable/nginx-ingress) requires no options/values when deploying it.
-* ProTip: Place in the ingress controller in a different namespace, e.g. `ingress` with the `--namespace` option.
+* ProTip: Place the ingress controller in a different namespace, e.g. `ingress` by using the `--namespace` option.
 * Use `kubectl get service` (add `--namespace` if you deployed it to a different namespace) to discover the public/external IP of your ingress controller, you will need to make a note of it. the
-* [nip.io](https://nip.io) is not related to Kubernetes or Azure, however it provide useful service of mapping any IP Address to a hostname. This saves you needed to create public DNS records. If your ingress controller had IP 12.34.56.78, you could access it via `http://anythingyouwant.12.34.56.78.nip.io`
+* [nip.io](https://nip.io) is not related to Kubernetes or Azure, however it provides a useful service to map any IP Address to a hostname. This saves you having to create public DNS records. If your ingress controller had IP 12.34.56.78, you could access it via `http://anythingyouwant.12.34.56.78.nip.io`
 * The [Kubernetes docs have an example of creating an Ingress object](https://kubernetes.io/docs/concepts/services-networking/ingress/#name-based-virtual-hosting), except you will only be specifying a single host rule. Use nip.io and your ingress controller IP to set the `host` field. As with the deployment and service, you create this object via a YAML file and `kubectl apply`
 
 {% collapsible %}
@@ -181,6 +183,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: frontend
+  annotations:
+    kubernetes.io/ingress.class: nginx
 spec:
   rules:
   - host: frontend._INGRESS_CONTROLLER_EXTERNAL_IP_.nip.io
@@ -204,9 +208,9 @@ kubectl apply -f frontend-ingress.yaml
 
 Once the Ingress is deployed, you should be able to access the frontend at <http://frontend.[cluster_specific_dns_zone]>, for example <http://frontend.52.255.217.198.nip.io>
 
-If it doesn't work from the first trial, give it a few more minutes or try a different browser.
+If it doesn't work on the first attempt, give it a few more minutes or try a different browser.
 
-Note: you might need to enable cross-scripting in your browser; click on the shield icon on the address bar (for Chrome) and allow unsafe script to be executed. 
+Note: you might need to enable cross-site scripting in your browser; click on the shield icon on the address bar (for Chrome) and allow unsafe script to be executed. 
 
 ![Orders frontend](media/ordersfrontend.png)
 
@@ -217,6 +221,6 @@ Note: you might need to enable cross-scripting in your browser; click on the shi
 > * <https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/>
 
 ### Architecture Diagram
-If you want a picture of how the system should look at the end of this challenge click below
+Here's a high level diagram of the components you will have deployed when you've finished this section (click the picture to enlarge)
 
 <a href="media/architecture/frontend.png" target="_blank"><img src="media/architecture/frontend.png" style="width:500px"></a>

--- a/_entries/02-05 challenge2-4.md
+++ b/_entries/02-05 challenge2-4.md
@@ -1,13 +1,11 @@
 ---
 sectionid: tls
 sectionclass: h2
-title: Enable SSL/TLS on ingress
+title: Enable TLS (SSL) on ingress
 parent-id: upandrunning
 ---
 
-You want to enable connecting to the frontend website over SSL/TLS. In this task, you'll use [Let's Encrypt](https://letsencrypt.org/) free service to generate valid SSL certificates for your domains, and you'll integrate the certificate issuance workflow into Kubernetes.
-
-> **Important** After you finish this task for the `frontend`, you may either receive some browser warnings about "mixed content" or the orders might not load at all because the calls happen via JavaScript. Use the same concepts to create an ingress for `captureorder` service and use SSL/TLS to secure it in order to fix this.
+You want to enable secure connections to the Frontend website over TLS (SSL). In this task, you'll use [Let's Encrypt](https://letsencrypt.org/)'s free service to generate valid TLS certificates for your domains, and you'll integrate the certificate issuance workflow into Kubernetes.
 
 ### Tasks
 
@@ -16,7 +14,7 @@ You want to enable connecting to the frontend website over SSL/TLS. In this task
 [cert-manager](https://github.com/jetstack/cert-manager) is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources. It will ensure certificates are valid and up to date periodically, and attempt to renew certificates at an appropriate time before expiry.
 
 **Task Hints**
-* As with MongoDB and NGINX use Helm to deploy cert-manager. You need to do a little more than just `helm install` however the [steps are documented in the GitHub repo for the cert-manager chart](https://github.com/helm/charts/tree/master/stable/cert-manager#installing-the-chart)
+* As with MongoDB and NGINX use Helm to deploy cert-manager. You need to do a little more than just `helm install`, however the [steps are documented in the GitHub repo for the cert-manager chart](https://github.com/helm/charts/tree/master/stable/cert-manager#installing-the-chart)
 * It's recommended to install the chart into a different/name namespace
 
 {% collapsible %}
@@ -46,7 +44,7 @@ helm install cert-manager \
 
 #### Create a Let's Encrypt ClusterIssuer
 
-In order to begin issuing certificates, you will need to set up a ClusterIssuer.
+In order to begin issuing certificates, you will need to set up a `ClusterIssuer`.
 
 **Task Hints**
 * cert-manager uses a custom Kubernetes object called an **Issuer** or **ClusterIssuer** to act as the interface between you and the certificate issuing service (in our case Let's Encrypt). There are many ways to create an issuer, but [the cert-manager docs provides a working example YAML for Let's Encrypt](https://cert-manager.readthedocs.io/en/latest/reference/issuers.html#issuers). It will require some small modifications, **You must change the type to `ClusterIssuer` or it will not work**. The recommendation is you call the issuer `letsencrypt`
@@ -90,8 +88,8 @@ Issuing certificates can be done automatically by properly annotating the ingres
 
 **Task Hints**
 * You need to make changes to the frontend ingress, you can modify your existing frontend ingress YAML file or make a copy to a new name
-* [The quick start guide for cert-manager provides guidance on the changes you need to make](https://cert-manager.readthedocs.io/en/latest/tutorials/acme/quick-start/index.html#step-7-deploy-a-tls-ingress-resource). Note the follow:
-  * The annotation `cert-manager.io/issuer: "letsencrypt-staging"` in the metadata, you want that to refer to your issuer, e.g. `letsencrypt`
+* [The quick start guide for cert-manager provides guidance on the changes you need to make](https://cert-manager.readthedocs.io/en/latest/tutorials/acme/quick-start/index.html#step-7-deploy-a-tls-ingress-resource). Note the following:
+  * The annotation `cert-manager.io/issuer: "letsencrypt-staging"` in the metadata, you want that to refer to your issuer `letsencrypt` and use cluster-issuer rather than issuer, e.g. `cert-manager.io/cluster-issuer: "letsencrypt"`
   * The new `tls:` section, here the `host` field should match the host in your rules section, and the `secretName` can be anything you like, this will be the name of the certificate issued (see next step)
 * Reapply your changed frontend ingress using `kubectl`
 
@@ -107,6 +105,7 @@ kind: Ingress
 metadata:
   name: frontend
   annotations:
+    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
   tls:
@@ -135,12 +134,9 @@ kubectl apply -f frontend-ingress-tls.yaml
 #### Verify the certificate is issued and test the website over SSL
 
 **Task Hints**
-* You can list custom objects such as certificates with regular `kubectl commands`, e.g. `kubectl get cert` and `kubectl describe cert`, use the describe command to validate the cert has been issued and is valid
-* Access the front end in your browser as before, e.g. http://frontend.{ingress-ip}.nip.io you might be automatically redirected to the `https://` version, if not modify the URL to access using `https://`
-* You will probably see nothing in the Orders view, and many errors in the dev console (F12), to fix this you will need to do some work to make the orders API accessible over HTTPS with TLS:
-  * Repeat the work you did when creating the frontend ingress, but this time for the captureorder service, i.e. direct traffic via the ingress (create an second ingress object using YAML) 
-  * The hostname will need to be different, but still point at your ingress controller IP, e.g. `orders.{ingress-ip}.nip.io`. You must set up TLS for it as you did with the frontend
-  * Modify the `CAPTUREORDERSERVICEIP` environmental variable in the frontend deployment YAML. This now needs to refer to the hostname of your orders ingress, re-deploy the frontend to make the changes live
+* You can list custom objects such as certificates with regular `kubectl` commands, e.g. `kubectl get cert` and `kubectl describe cert`, use the describe command to validate the cert has been issued and is valid
+* Access the front end in your browser as before, e.g. `http://frontend.{ingress-ip}.nip.io` you might be automatically redirected to the `https://` version, if not modify the URL to access using `https://`
+* **You will probably see nothing in the Orders view, and some errors in the developer console (F12)**, to fix this you will need to do some work to make the Order Capture API accessible over HTTPS with TLS. See the next section for more details.
   
 {% collapsible %}
 
@@ -153,40 +149,154 @@ kubectl describe certificate frontend
 You should get back something like:
 
 ```sh
-Name:         frontend
+Name:         frontend-tls-secret
 Namespace:    default
 Labels:       <none>
-Annotations:  kubectl.kubernetes.io/last-applied-configuration:
-                {"apiVersion":"cert-manager.io/v1alpha1","kind":"Certificate","metadata":{"annotations":{},"name":"frontend","namespace":"default"},"sp...
-API Version:  cert-manager.io/v1alpha1
+Annotations:  <none>
+API Version:  cert-manager.io/v1alpha2
 Kind:         Certificate
 Metadata:
-  Creation Timestamp:  2019-02-13T02:40:40Z
-  Generation:          1
-  Resource Version:    11448
-  Self Link:           /apis/cert-manager.io/v1alpha1/namespaces/default/certificates/frontend
-  UID:                 c0a620ee-2f38-11e9-adae-0a58ac1f1147
+  Creation Timestamp:  2020-01-30T14:14:53Z
+  Generation:          2
+  Owner References:
+    API Version:           extensions/v1beta1
+    Block Owner Deletion:  true
+    Controller:            true
+    Kind:                  Ingress
+    Name:                  frontend
+    UID:                   069293aa-68a8-4d63-8093-9b82f018f985
+  Resource Version:        326924
+  Self Link:               /apis/cert-manager.io/v1alpha2/namespaces/default/certificates/frontend-tls-secret
+  UID:                     acf4834f-5ad7-42da-b660-be0dfed7eae0
 Spec:
-  Acme:
-    Config:
-      Domains:
-        frontend.52.255.217.198.nip.io
-      Http 01:
-        Ingress Class:  addon-http-application-routing
   Dns Names:
-    frontend.52.255.217.198.nip.io
+    frontend.51.105.126.236.nip.io
   Issuer Ref:
+    Group:      cert-manager.io
     Kind:       ClusterIssuer
     Name:       letsencrypt
   Secret Name:  frontend-tls-secret
+Status:
+  Conditions:
+    Last Transition Time:  2020-01-30T14:19:32Z
+    Message:               Certificate is up to date and has not expired
+    Reason:                Ready
+    Status:                True
+    Type:                  Ready
+  Not After:               2020-04-29T13:19:31Z
+Events:
+  Type    Reason        Age    From          Message
+  ----    ------        ----   ----          -------
+  Normal  GeneratedKey  6m23s  cert-manager  Generated a new private key
+  Normal  Requested     6m23s  cert-manager  Created new CertificateRequest resource "frontend-tls-secret-21669938"
+  Normal  Requested     2m11s  cert-manager  Created new CertificateRequest resource "frontend-tls-secret-253990887"
+  Normal  Issued        104s   cert-manager  Certificate issued successfully
+
 ```
 
 Verify that the frontend is accessible over HTTPS and that the certificate is valid.
 
 ![Let's Encrypt SSL certificate](media/ssl-certificate.png)
 
-Note: even if the certificate is valid, you may still get a warning in your browser because of the unsafe cross-scripting.
+Note: even if the certificate is valid, you may still get a warning in your browser because of the unsafe cross-site scripting.
 
+
+{% endcollapsible %}
+
+#### Enable TLS for the Order Capture API to fix the Frontend application
+
+  You should have noticed that the Frontend application now appears to be broken as it displays the **Orders** title but no order details beneath. This is because the Order Capture API is still using an unsecured HTTP connection and your web browser is blocking this unsafe content. To fix this, we need to enable TLS for the Order Capture API as well.
+
+**Task Hints**
+  * This is pretty much a repeat of the work you did when creating the Frontend ingress resource, so you just need to make a copy of the ingress YAML and configure it to direct traffic to the 'captureorder' service. 
+  * You will need a new hostname, but it can still use the same Ingress Controller - for example `ordercapture.{ingress-ip}.nip.io`.
+  * The web root of the Capture Order API returns a 404. During setup of the cert, LetsEncrypt may send a challenge to the address you specify for the Caputure Order API to ensure it's valid, but it will be expecting a 200 response. Therefore, you may need to configre the Ingress to redirect traffic from root `/` to a location that returns a response, such as `/v1/order`
+  * Modify the `CAPTUREORDERSERVICEIP` environment variable in the Frontend deployment YAML. This now needs to refer to the hostname of your new `ordercapture` ingress instead of the IP address of the `ordercapture` service. You will need to redeploy the frontend to make the changes live.
+
+{% collapsible %}
+
+#### Create a new Kubernetes Ingress resource to direct traffic to the `captureorder` service
+
+Save the YAML below as `captureorder-ingress-tls.yaml` or download it from [captureorder-ingress-tls.yaml](yaml-solutions/advanced/captureorder-ingress-tls.yaml).
+
+> **Note** Make sure to replace `_INGRESS_CONTROLLER_EXTERNAL_IP_` with your cluster's ingress controller external IP.
+
+```sh
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: captureorder
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt
+    nginx.ingress.kubernetes.io/app-root: /v1/order
+spec:
+  tls:
+  - hosts:
+    - captureorder._INGRESS_CONTROLLER_EXTERNAL_IP_.nip.io
+    secretName: captureorder-tls-secret
+  rules:
+  - host: captureorder._INGRESS_CONTROLLER_EXTERNAL_IP_.nip.io
+    http:
+      paths:
+      - backend:
+          serviceName: captureorder
+          servicePort: 80
+        path: /
+```
+
+You should now be able to query the `/v1/orders` endpoint or open the `/swagger` endpoint using HTTPS.
+
+#### Update the Frontend deployment to use HTTPS to access the Capture Order API 
+
+We need to redeploy the Frontend application so that it accesses the Capture Order API via the newly created Ingress
+
+Save the YAML below as `frontend-deployment.yaml` or download it from [frontend-deployment.yaml](yaml-solutions/advanced/frontend-deployment.yaml).
+
+> **Note** Make sure to replace `_INGRESS_CONTROLLER_EXTERNAL_IP_` with your cluster's ingress controller external IP.
+
+```sh
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+      matchLabels:
+        app: frontend
+  replicas: 1
+  template:
+      metadata:
+        labels:
+            app: frontend
+      spec:
+        containers:
+        - name: frontend
+          image: azch/frontend
+          imagePullPolicy: Always
+          readinessProbe:
+            httpGet:
+              port: 8080
+              path: /
+          livenessProbe:
+            httpGet:
+              port: 8080
+              path: /
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+          env:
+          - name: CAPTUREORDERSERVICEIP
+            value: "captureorder._INGRESS_CONTROLLER_EXTERNAL_IP_.nip.io"
+          ports:
+          - containerPort: 8080
+```
+
+You should now be able to open the Frontend application and the order information should be displayed correctly.
 
 {% endcollapsible %}
 
@@ -196,6 +306,6 @@ Note: even if the certificate is valid, you may still get a warning in your brow
 > * <https://cert-manager.readthedocs.io/en/latest/tutorials/acme/quick-start>
 
 ### Architecture Diagram
-If you want a picture of how the system should look at the end of this challenge click below
+Here's a high level diagram of the components you will have deployed when you've finished this section (click the picture to enlarge)
 
 <a href="media/architecture/tls-certs.png" target="_blank"><img src="media/architecture/tls-certs.png" style="width:500px"></a>

--- a/_entries/02-06 challenge3.md
+++ b/_entries/02-06 challenge3.md
@@ -14,7 +14,7 @@ Use a combination of the available tools to setup alerting capabilities for your
 #### Create Log Analytics workspace
 
 **Task Hints**
-* To store monitoring data, events and metrics from your Kubernetes cluster and the applications. Azure Monitor can be used, specifically a component of Azure Monitor called [Log Analytics](https://docs.microsoft.com/en-us/azure/azure-monitor/log-query/get-started-portal).
+* To store monitoring data, events and metrics from your Kubernetes cluster and the applications, Azure Monitor can be used. Specifically a component of Azure Monitor called [Log Analytics](https://docs.microsoft.com/en-us/azure/azure-monitor/log-query/get-started-portal).
 * The Azure documentation has [guidance on how to create a new Log Analytics workspace](https://docs.microsoft.com/en-us/azure/azure-monitor/learn/quick-create-workspace) using the portal.
 
 {% collapsible %}
@@ -37,7 +37,7 @@ az resource create --resource-type Microsoft.OperationalInsights/workspaces \
 #### Enable the monitoring addon
 
 **Task Hints**
-* The monitoring add-on also known as "Azure Monitor for containers" is [comprehensive monitoring solution for Kubernetes](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/container-insights-overview)
+* The monitoring add-on, also known as "Azure Monitor for containers" is [a comprehensive monitoring solution for Kubernetes](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/container-insights-overview)
 * To enable the add-on you can use the portal or the Azure CLI, and [integrate with the existing workspace you created in the last task](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/container-insights-enable-existing-clusters#integrate-with-an-existing-workspace)
 
 {% collapsible %}
@@ -56,7 +56,7 @@ az aks enable-addons --resource-group <resource-group> --name <unique-aks-cluste
 
 {% endcollapsible %}
 
-#### Leverage integrated Azure Kubernetes Service monitoring to figure out if requests are failing, inspect Kubernetes event or logs and monitor your cluster health
+#### Leverage integrated Azure Kubernetes Service monitoring to figure out if requests are failing, inspect Kubernetes events or logs and monitor your cluster health
 
 **Task Hints**
 * View the utilization reports and charts in the Azure portal, via the "Insights" view on your AKS cluster
@@ -76,7 +76,7 @@ az aks enable-addons --resource-group <resource-group> --name <unique-aks-cluste
 
 **Task Hints**
 * You can view live log data from the 'Containers' tab in the Insights view, with the "View live data (preview)" button.
-* Will get an error, this can be fixed by setting up some RBAC roles and accounts in your cluster. [This is covered in the AKS documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/container-insights-live-logs). You might need to refresh the page in the portal for the changes to take effect.
+* You will get an error which can be fixed by setting up some RBAC roles and accounts in your cluster. [This is covered in the AKS documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/container-insights-live-logs). You might need to refresh the page in the portal for the changes to take effect.
 
 {% collapsible %}
 
@@ -189,7 +189,7 @@ Save the YAML below as `prommetrics-demo.yaml` or download it from [prommetrics-
 
 2. Generate traffic to the application by running curl. 
 
-  Find the pod you just created.
+  Find the pods you just created.
 
   ```sh
   kubectl get pods | grep prommetrics-demo
@@ -232,8 +232,11 @@ Save the YAML below as `prommetrics-demo.yaml` or download it from [prommetrics-
 
 4.	Query the Prometheus metrics and plot a chart. 
 
-  To access Log Analytics, go to the AKS overview page and click `Logs` in the TOC under Monitor. 
-  Copy the query below and run. 
+  To access Log Analytics, go to the overview page for your AKS cluster and click `Logs` in the list of options on the left hand side under Monitor. 
+ 
+ Copy the query below and run. 
+
+ > **Note** It can take several minutes for the log data to appear in Log Analytics. If you see "NO RESULTS FOUND", maybe try the next exercise and return later to view the data.
 
   ```
   InsightsMetrics

--- a/_entries/02-08 acr.md
+++ b/_entries/02-08 acr.md
@@ -2,7 +2,7 @@
 sectionclass: h2
 sectionid: acr
 parent-id: upandrunning
-title: Create private highly available container registry 
+title: Create a private highly available container registry 
 ---
 
 Instead of using the public Docker Hub registry, create your own private container registry using Azure Container Registry (ACR).
@@ -19,7 +19,7 @@ Instead of using the public Docker Hub registry, create your own private contain
 {% collapsible %}
 
 ```sh
-az acr create --resource-group <resource-group> --name <unique-acr-name> --sku Standard --location eastus
+az acr create --resource-group <resource-group> --name <unique-acr-name> --sku Standard --location <location>
 ```
 
 {% endcollapsible %}
@@ -50,7 +50,7 @@ Use Azure Container Registry Build to build and push the container images
 az acr build -t "captureorder:{% raw %}{{.Run.ID}}{% endraw %}" -r <unique-acr-name> .
 ```
 
-> **Note** You'll get a build ID in a message similar to ``Run ID: ca3 was successful after 3m14s``. Use `ca3` in this example as the image tag in the next step.
+> **Note** On completion you'll get a build ID in a message similar to ``Run ID: cb1 was successful after 3m14s``. Use that Run ID (`cb1` in this example) as the image tag in the next step.
 
 {% endcollapsible %}
 
@@ -71,6 +71,24 @@ Authorize the AKS cluster to connect to the Azure Container Registry.
 az aks update -n <aks-cluster-name> -g <resource-group> --attach-acr <your-acr-name>
 ```
 
+> **Note** If the above command results in an error, it's possible you may not have the necessary permissions to configure ACR access. If this happens, the following method may work.
+
+```sh
+AKS_RESOURCE_GROUP=<Resource Group where AKS is deployed>
+AKS_CLUSTER_NAME=<Name of your AKS Cluster>
+ACR_RESOURCE_GROUP=<Resource Group where ACR is deployed>
+ACR_NAME=<Name of your Azure Container Registry>
+
+# Get the id of the service principal configured for AKS
+CLIENT_ID=$(az aks show --resource-group $AKS_RESOURCE_GROUP --name $AKS_CLUSTER_NAME --query "servicePrincipalProfile.clientId" --output tsv)
+
+# Get the ACR registry resource id
+ACR_ID=$(az acr show --name $ACR_NAME --resource-group $ACR_RESOURCE_GROUP --query "id" --output tsv)
+
+# Create role assignment
+az role assignment create --assignee $CLIENT_ID --role acrpull --scope $ACR_ID
+```
+
 {% endcollapsible %}
 
 After you grant your Kubernetes cluster access to your private registry, you can update your deployment with the image you built in the previous step.
@@ -78,8 +96,8 @@ After you grant your Kubernetes cluster access to your private registry, you can
 Kubernetes is declarative and keeps a manifest of all object resources. Edit your deployment object with the updated image.
 
 **Task Hints**
-* You can edit a live deployment object in Kubernetes with `kubectl edit deployment`. It is suggested to run `export KUBE_EDITOR="nano"` to stop `kubectl` from using the vi editor.
-* The image name will need to be fully qualify and include your registry name which will be of the form `<name>.azurecr.io/<image>:<tag>`
+* You can edit a live deployment object in Kubernetes with `kubectl edit deployment`. It is suggested to run `export KUBE_EDITOR="nano"` to stop `kubectl` from using the `vi` editor.
+* The image name will need to be fully qualified and include your registry name which will be of the form `<name>.azurecr.io/<image>:<tag>`
 
 {% collapsible %}
 
@@ -87,13 +105,13 @@ From your Azure Cloud Shell run:
 
 `kubectl edit deployment captureorder`
 
-Replace the image tag with the location of the new image on Azure Container Registry. Replace `<build id>` with the ID you got from the message similar to ``Run ID: ca3 was successful after 3m14s`` after the build was completed.
+Replace the image tag with the location of the new image on Azure Container Registry. Replace `<build id>` with the ID you got from the message similar to ``Run ID: cb1 was successful after 3m14s`` after the build was completed.
 
 > **Hint** `kubectl edit` launches `vim`. To search in `vim` you can type `/image: azch/captureorder`. Go into **insert** mode by typing `i`, and replace the image with `<unique-acr-name>.azurecr.io/captureorder:<build id>`
 
 Quit the editor by hitting `Esc` then typing `:wq` and run `kubectl get pods -l app=captureorder -w`.
 
-If you successfully granted Kubernetes authorization to your private registry you will see one pod terminating and a new one creating. If the access to your private registry was properly granted to your cluster, your new pod should be up and running within 10 seconds.
+If you successfully granted Kubernetes authorization to your private registry you will see one pod terminating and a new one creating. If the access to your private registry was properly granted to your cluster, your new pod should be up and running within about 10 seconds.
 
 {% endcollapsible %}
 

--- a/_entries/99 Contributors.md
+++ b/_entries/99 Contributors.md
@@ -18,6 +18,7 @@ The following people have contributed to this workshop, thanks!
 {% githubauthor kevingbb %}
 {% githubauthor khaled99b %}
 {% githubauthor marrobi %}
+{% githubauthor markwme %}
 {% githubauthor sabbour %}
 {% githubauthor shanepeckham %}
 {% githubauthor thorstenhans %}

--- a/yaml-solutions/01. challenge-02/frontend-ingress.yaml
+++ b/yaml-solutions/01. challenge-02/frontend-ingress.yaml
@@ -2,6 +2,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: frontend
+  annotations:
+    kubernetes.io/ingress.class: nginx
 spec:
   rules:
   - host: frontend._INGRESS_CONTROLLER_EXTERNAL_IP_.nip.io

--- a/yaml-solutions/advanced/captureorder-ingress-tls.yaml
+++ b/yaml-solutions/advanced/captureorder-ingress-tls.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: captureorder
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt
+    nginx.ingress.kubernetes.io/app-root: /v1/order
+spec:
+  tls:
+  - hosts:
+    - captureorder._INGRESS_CONTROLLER_EXTERNAL_IP_.nip.io
+    secretName: captureorder-tls-secret
+  rules:
+  - host: captureorder._INGRESS_CONTROLLER_EXTERNAL_IP_.nip.io
+    http:
+      paths:
+      - backend:
+          serviceName: captureorder
+          servicePort: 80
+        path: /

--- a/yaml-solutions/advanced/frontend-deployment.yaml
+++ b/yaml-solutions/advanced/frontend-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+      matchLabels:
+        app: frontend
+  replicas: 1
+  template:
+      metadata:
+        labels:
+            app: frontend
+      spec:
+        containers:
+        - name: frontend
+          image: azch/frontend
+          imagePullPolicy: Always
+          readinessProbe:
+            httpGet:
+              port: 8080
+              path: /
+          livenessProbe:
+            httpGet:
+              port: 8080
+              path: /
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+          env:
+          - name: CAPTUREORDERSERVICEIP
+            value: "captureorder._INGRESS_CONTROLLER_EXTERNAL_IP_.nip.io"
+          ports:
+          - containerPort: 8080

--- a/yaml-solutions/advanced/frontend-ingress-tls.yaml
+++ b/yaml-solutions/advanced/frontend-ingress-tls.yaml
@@ -3,6 +3,7 @@ kind: Ingress
 metadata:
   name: frontend
   annotations:
+    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
   tls:


### PR DESCRIPTION
Made several changes, mainly typos, clarifying text and adding extra descriptions, tips etc, in sections 1 and 2.

Summary of changes:

- Fixed some general typos
- Updated remaining references to Helm 2 to Helm v3
- Moved text regarding the Kubernetes Learning path to the "Kubernetes Basics" section
- Removed toggle wrapper from "Uploading and editing files in Azure Cloud Shell" section so this info is more obvious
- Updated Tasks section with wording about making progress during team based hacks and expected progress
- Add command to get latest non-preview version of Kubernetes
- Update explanation of Cluster Autoscaler
- Added description of pod, deployment and service to the end of the section 2.2
- Removed "Build Status" from table in section 2.3
- Add `requests` and `limits` as best practice
- Removed "Build Status" from table in section 2.4
- Added mention of Azure Application Gateway Ingress Controler in section 2.4
- Added nginx ingress annotations to frontend-ingress.yaml files
- Updated sample output of frontend certificate
- Added solution for setting up TLS on the Order Capture API
- Updated captureorder-hpa.yaml in docs to match file contents (minReplicas was different between the two)
- Added hints about using kubectl describe hpa and kubectl top when monitoring autoscaling         
- Added alternative method for configuring AKS access to ACR, based on errors seen in some workshop environments
